### PR TITLE
Update psi-spell-encode-wasm to 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"psi-spell-encode-wasm": "^2.0.6"
+		"psi-spell-encode-wasm": "^2.0.8"
 	},
 	"devDependencies": {
 		"eslint": "^8.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   psi-spell-encode-wasm:
-    specifier: ^2.0.6
-    version: 2.0.6
+    specifier: ^2.0.8
+    version: 2.0.8
 
 devDependencies:
   eslint:
@@ -927,8 +931,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /psi-spell-encode-wasm@2.0.6:
-    resolution: {integrity: sha512-ehTKaXAVYpvedONSjMByttxM29k13iR3ScJgTHuKVhv80GdSu6OmSQxo0WfJ4CnFWjo+qIZ3Ldkp1xR8vbYCsg==}
+  /psi-spell-encode-wasm@2.0.8:
+    resolution: {integrity: sha512-KPngHNYmu+HJNc5Ud5tXcQVyUwxftV9TxAEvWKMGrMktndrXsr+30gD1QdEPLaRBuSFf3AY2NICOtYxOQjXb9A==}
     dev: false
 
   /punycode@2.3.0:


### PR DESCRIPTION
Fixes empty spell name exporting